### PR TITLE
Convert step files to Raspberry Flavoured Markdown

### DIFF
--- a/en/step_1.md
+++ b/en/step_1.md
@@ -1,15 +1,12 @@
-<h2 class="c-project-heading--task">Astro Pi Mission Zero</h2>
+## Astro Pi Mission Zero
 
 Mission Zero offers young people the chance to have their code run in space!
 
-<h2 class="c-project-heading--explainer">Example</h2>
-
 Write a simple program to take a reading from the colour and luminosity sensor on an Astro Pi computer on board the International Space Station. Use it to set the background colour in a personalised image for the astronauts to see as they go about their daily tasks.
 
-<div class="c-project-output">
 <iframe src="https://editor.raspberrypi.org/en/embed/viewer/editor-astro-pi-mission-zero-complete" width="600" height="600" frameborder="0" marginwidth="0" marginheight="0" allowfullscreen title="Mission Zero example"> </iframe>
-</div>
- Click **Run** and then change the colour sensor.
+
+Click **Run** and then change the colour sensor.
 
 ## Now run your code
 

--- a/en/step_2.md
+++ b/en/step_2.md
@@ -1,10 +1,6 @@
-<h2 class="c-project-heading--task">Colour the LEDs</h2>
+## Colour the LEDs
 
 Experiment with colour values to see what they look like.
-
-<h2 class="c-project-heading--explainer">Red, Green, and Blue</h2>
-
-## Step 1
 
 Computers use three numbers to describe a colour.
 
@@ -18,43 +14,21 @@ In the code on the right, the colour (`c`) is set to black `(0, 0, 0)`.
 
 Change the values of `c` and run the code to see what different colours you can make.
 
-
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 13
-line_highlights: 14
----
+```python filename="main.py" line_numbers="true" line_number_start="13" line_highlights="14"
 # Add colour variables and image
 c = (248, 24, 148)
---- /code ---
-</div>
+```
 
-## Step 2
+> [!TIP]
+>
+> You can use an [RGB colour picker](https://share.google/WkKa3VbOYnhYYkC9h) to find `RGB` values.
 
-<div class="c-project-output">
-![astro pi displaying an all pink screen](images/pink-screen.png)
-</div>
-
-### Tip
-
-<div class="c-project-callout c-project-callout--tip">
-
-You can use an [RGB colour picker](https://share.google/WkKa3VbOYnhYYkC9h) to find `RGB` values.
-
-</div>
-
-### Debugging
-
-<div class="c-project-callout c-project-callout--debug">
-
-Check that you have commas (`,`) between the numbers you have chosen.
-
-</div>
+> [!DEBUG]
+>
+> Check that you have commas (`,`) between the numbers you have chosen.
 
 ## Now run your code
 
 Run your code and check that the whole screen changes colour.
+
+![astro pi displaying an all pink screen](images/pink-screen.png)

--- a/en/step_2.md
+++ b/en/step_2.md
@@ -2,7 +2,7 @@
 
 Experiment with colour values to see what they look like.
 
-<h2 class="c-project-heading--explainer">Red, Green and Blue</h2>
+<h2 class="c-project-heading--explainer">Red, Green, and Blue</h2>
 
 ## Step 1
 
@@ -57,4 +57,4 @@ Check that you have commas (`,`) between the numbers you have chosen.
 
 ## Now run your code
 
-Run your code and check that the whole screen turns pink.
+Run your code and check that the whole screen changes colour.

--- a/en/step_3.md
+++ b/en/step_3.md
@@ -8,7 +8,7 @@ You can change the colours of specific LEDs.
 
 Individual LEDs are shown in the list called `image`.
 
-This is an 8 x 8 grid of letters. Each letter colours a pixel on the Astro Pi.
+This is an 8 x 8 grid of letters. Each letter colours a pixel on the Astro Pi's screen.
 
 At the moment, every LED is coloured with the `c` colour you chose.
 

--- a/en/step_3.md
+++ b/en/step_3.md
@@ -1,10 +1,6 @@
-<h2 class="c-project-heading--task">Colour different LEDs</h2>
+## Colour different LEDs
 
 You can change the colours of specific LEDs.
-
-<h2 class="c-project-heading--explainer">LEDs as a list</h2>
-
-## Step 1
 
 Individual LEDs are shown in the list called `image`.
 
@@ -14,16 +10,7 @@ At the moment, every LED is coloured with the `c` colour you chose.
 
 Create a new colour and change some of the LEDs to use that colour.
 
-
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 13
-line_highlights: 15, 18-25
----
+```python filename="main.py" line_numbers="true" line_number_start="13" line_highlights="15,18-25"
 # Add colour variables and image
 c = (248, 24, 148)
 d = (128, 0, 128)
@@ -39,22 +26,14 @@ image = [
     d, c, c, c, c, c, c, d
     ]
 
---- /code ---
-</div>
+```
 
-## Step 2
-
-<div class="c-project-output">
-![astro pi with a pink screen and a purple cross](images/purple-cross.png)
-</div>
-
-### Debugging
-
-<div class="c-project-callout c-project-callout--debug">
-
-Have you added a second colour? In the example `d = (128, 0, 128)`.
-</div>
+> [!DEBUG]
+>
+> Have you added a second colour? In the example `d = (128, 0, 128)`.
 
 ## Now run your code
 
 Run your code and check that you see a purple cross on the pink background.
+
+![astro pi with a pink screen and a purple cross](images/purple-cross.png)

--- a/en/step_4.md
+++ b/en/step_4.md
@@ -74,4 +74,4 @@ Check that you have 8 columns and 8 rows of colours in your image, and that ther
 
 ## Now run your code
 
-Run your code and check that your own 8x8 picture appears on the LED matrix.
+Run your code and check that your own 8 x 8 picture appears on the LED matrix.

--- a/en/step_4.md
+++ b/en/step_4.md
@@ -1,32 +1,16 @@
-<h2 class="c-project-heading--task">Draw a picture</h2>
+## Draw a picture
 
 Edit your `image` to create your own picture.
-
-## Step 1
 
 By adding more colours and changing the `image` list, you can create your very own picture on the LED matrix.
 
 The following is an example of a fish.
 
-<div class="c-project-output">
 ![fish](images/fish.png)
-</div>
-
-## Step 2
 
 Replace the code below to use your own colours and create your own image.
 
-
-
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 13
-line_highlights: 14-17, 20-27
----
+```python filename="main.py" line_numbers="true" line_number_start="13" line_highlights="14-17,20-27"
 # Add colour variables and image
 z = (153, 50, 204) # Tail and fins
 q = (255, 255, 0) # Body
@@ -43,35 +27,22 @@ image = [
     z, d, q, z, z, q, d, d,
     d, d, d, z, d, d, d, d,
     ]
---- /code ---
-</div>
+```
 
-## Step 3
+> [!TIP]
+>
+> It might help to design your picture on some squared paper.
+>
+> Or you can use a pixel art app like [Piskel](https://www.piskelapp.com/kids/).
 
-<div class="c-project-output">
-![astro pi displaying a yellow and purple fish with a black eye](images/astro-fish.png)
-</div>
-
-### Tip
-
-<div class="c-project-callout c-project-callout--tip">
-
-It might help to design your picture on some squared paper.
-
-Or you can use a pixel art app like [Piskel](https://www.piskelapp.com/kids/).
-
-</div>
-
-### Debugging
-
-<div class="c-project-callout c-project-callout--debug">
-
-Make sure that every letter used in your image has an RGB value set.
-
-Check that you have 8 columns and 8 rows of colours in your image, and that there are commas at the end of each row.
-
-</div>
+> [!DEBUG]
+>
+> Make sure that every letter used in your image has an RGB value set.
+>
+> Check that you have 8 columns and 8 rows of colours in your image, and that there are commas at the end of each row.
 
 ## Now run your code
 
 Run your code and check that your own 8 x 8 picture appears on the LED matrix.
+
+![astro pi displaying a yellow and purple fish with a black eye](images/astro-fish.png)

--- a/en/step_5.md
+++ b/en/step_5.md
@@ -1,8 +1,6 @@
-<h2 class="c-project-heading--task">Sense a colour</h2>
+## Sense a colour
 
 The Astro Pi has a colour sensor to detect colours.
-
-<h2 class="c-project-heading--explainer">Use the colour sensor to change your image</h2>
 
 Choose a new letter to store the colour the Astro Pi's sensor reads.
 
@@ -14,15 +12,7 @@ It could be:
 - The colour of a flower's petals
 - Whatever you like
 
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 13
-line_highlights: 19-20
----
+```python filename="main.py" line_numbers="true" line_number_start="13" line_highlights="19-20"
 # Add colour variables and image
 z = (153, 50, 204) # Tail and fins
 q = (255, 255, 0) # Body
@@ -42,21 +32,16 @@ image = [
     z, d, q, z, z, q, d, d,
     d, d, d, z, d, d, d, d,
     ]
---- /code ---
-</div>
+```
 
 Before you click **Run**, change the colour on the colour sensor. You can click on the colour and use the picker to choose a new one.
 
-<div class="c-project-output">
 ![colour sensor](images/colour_sensor.png)
-</div>
+
 This simulates what an Astro Pi unit's colour sensor would detect.
-
-
-<div class="c-project-output">
-![astro pi with a fish displayed, now with purple fins to match the colour sensor](images/fish-purple-fins.png)
-</div>
 
 ## Now run your code
 
 Change the colour sensor, run your code, and check that part of the picture changes to match the sensor colour.
+
+![astro pi with a fish displayed, now with purple fins to match the colour sensor](images/fish-purple-fins.png)

--- a/en/step_6.md
+++ b/en/step_6.md
@@ -1,8 +1,6 @@
-<h2 class="c-project-heading--task">Keep the colour changing</h2>
+## Keep the colour changing
 
 The colour can be updated as the sensor changes.
-
-<h2 class="c-project-heading--explainer">Use a loop with a pause</h2>
 
 Add a `for` loop to your code so that the colour sensor is checked every second and your image is updated.
 
@@ -10,15 +8,7 @@ This program will run for 28 seconds. Each Mission Zero entry runs for only 30 s
 
 All the lines after the `for` loop need to have four spaces of indentation.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 13
-line_highlights: 19, 36
----
+```python filename="main.py" line_numbers="true" line_number_start="13" line_highlights="19,36"
 # Add colour variables and image
 z = (153, 50, 204) # Tail and fins
 q = (255, 255, 0) # Body
@@ -43,26 +33,18 @@ for i in range(28):
     # Display the image
     sense.set_pixels(image)
     sleep(1)
---- /code ---
-</div>
+```
 
 Run your program and then change the colour sensor value to see the picture change.
 
-
-<div class="c-project-output">
-![animation of astro pi showing colour picker being changed and fish colours changing as a result](images/colour-change.gif)
-</div>
-
-### Debugging
-
-<div class="c-project-callout c-project-callout--debug">
-
-Make sure you have **four** spaces of indentation on all lines below the `for` loop.
-
-Don't forget to add the `sleep(1)` on the last line to give you time to change the colours.
-
-</div>
+> [!DEBUG]
+>
+> Make sure you have **four** spaces of indentation on all lines below the `for` loop.
+>
+> Don't forget to add the `sleep(1)` on the last line to give you time to change the colours.
 
 ## Now run your code
 
 Run your program, change the colour sensor, and check that the picture updates when the sensor colour changes.
+
+![animation of astro pi showing colour picker being changed and fish colours changing as a result](images/colour-change.gif)


### PR DESCRIPTION
Converts all step files to the Raspberry Flavoured Markdown spec. (Project remains unpublished — `listed: false` unchanged.)

**Conversion**
- Task headings → `##`; explainer/`## Step N` scaffolding folded into prose (all steps are single-task); removed "Follow these instructions"
- Code → fenced blocks with inline attributes (code preserved)
- Tip/debug callouts → `> [!TIP]`/`> [!DEBUG]`; output wrappers dropped → bare images (instructional screenshots left inline)
- step_1 embedded `<iframe>` kept as raw HTML (unwrapped)

**SPAG:** step_1 stray leading space removed. No content/code errors found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)